### PR TITLE
Moved api from t-mobile to odido & Authentication code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
->> DOES NOT WORK!!!! I might update when someone proposes a fix on the Tweakers thread, however I do not use T-Mobile myself so it has 0 prio for me.
-
->> Update (2023-12-09): Someone proposed a [solution](https://gathering.tweakers.net/forum/list_message/76494790#76494790), I have yet to test this etc but will definetly have a look soon<sup>tm</sup>  
->> Update (2023-12-09 v2): Uuuh awkward, apparently my friend doesn't have tmobile/odido unlimited anymore so can't use his credentials to test. Since I have Vodafone myself it's impossible for me to develop.
-
 > Based on: https://gathering.tweakers.net/forum/view_message/69930184
 
-# T-Mobile Unlimited GO Auto Bundle Requester
+# Odido Unlimited Auto Bundle Requester
 
 ### Without needing to sniff your URL every month.
 It runs every 5 mins (can be set with ENV variable `UPDATE_INTERVAL`), and requests new bundle when MB's is less than 2000.
@@ -20,13 +15,17 @@ There are 3 main ways to use this software in production:
 2. running it as a Docker container
 3. running it as a Docker container via docker-compose
 
+## Authorization Token
+To run this script, an authorization token is needed.
+Obtain the token using the **Odido Authenticator tool**:
+[Odido Authenticator lastest Release](https://github.com/GuusBackup/Odido.Authenticator/releases/latest)
+
 ### Node.js with Yarn/NPM
 1. `git clone https://github.com/lodu/TMobile-NL-Unlimited-Bundle-Automated`
 2. `yarn` or `npm install`
 3.  create a file called `.env` in root folder with contents:
       ```bash
-      EMAIL=example@example.com
-      PASSWORD=3x4mp1e!
+      AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
       UPDATE_INTERVAL=5
       ```
@@ -38,8 +37,7 @@ There are 3 main ways to use this software in production:
 ### Docker
 1.  create a file called `.env`:
       ```bash
-      EMAIL=example@example.com
-      PASSWORD=3x4mp1e!
+      AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
       UPDATE_INTERVAL=5
       ```
@@ -49,8 +47,7 @@ There are 3 main ways to use this software in production:
 ### docker-compose
 1.  create a file called `.env`:
       ```bash
-      EMAIL=example@example.com
-      PASSWORD=3x4mp1e!
+      AUTHORIZATIONTOKEN=xxxxxxxxxx
       MSISDN=+3161234567890
       UPDATE_INTERVAL=5
       ```
@@ -61,8 +58,7 @@ There are 3 main ways to use this software in production:
 1. `git clone` the repo (duhh)
 2. Create `.env` file in root directory:
    ```bash
-   EMAIL=example@example.com
-   PASSWORD=3x4mp1e!
+   AUTHORIZATIONTOKEN=xxxxxxxxxx
    MSISDN=+3161234567890
    UPDATE_INTERVAL=5
    ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are 3 main ways to use this software in production:
 ## Authorization Token
 To run this script, an authorization token is needed.
 Obtain the token using the **Odido Authenticator tool**:
-[Odido Authenticator lastest Release](https://github.com/GuusBackup/Odido.Authenticator/releases/latest)
+[Odido Authenticator latest Release](https://github.com/GuusBackup/Odido.Authenticator/releases/latest)
 
 ### Node.js with Yarn/NPM
 1. `git clone https://github.com/lodu/TMobile-NL-Unlimited-Bundle-Automated`

--- a/src/providerModels/TMobile/index.ts
+++ b/src/providerModels/TMobile/index.ts
@@ -16,7 +16,7 @@ export default class TMobile {
   private PERSONAL_API_URI: string;
   private TMOBILE_MSISDN: string; // +3161234567890
   private DEFAULT_HEADERS: object = {
-    "User-Agent": "T-Mobile 5.3.28 (Android 10; 10)",
+    "User-Agent": "ODIDO 8.0.0 (Android 12; 12)",
   };
   private DEFAULT_AUTH_TOKEN_HEADERS: object = {
     Authorization: `Basic OWhhdnZhdDZobTBiOTYyaTo=`, // Can be used by anyone
@@ -26,73 +26,15 @@ export default class TMobile {
   private subscriptionURL: string;
   private buyingCode: string;
 
-  constructor(BASE_URI: string = "https://capi.t-mobile.nl") {
+  constructor(BASE_URI: string = "https://capi.odido.nl") {
     this.API_URI = BASE_URI;
     this.TMOBILE_MSISDN = process.env.MSISDN;
+    this.BearerAuthorizationCode = process.env.AUTHORIZATIONTOKEN
   }
 
-  private async getAuthorizationCode(): Promise<string> {
-    let AuthorizationCode: string = null;
-
-    const URI: string = `${this.API_URI}/login?response_type=code`;
-    const headers: Headers = makeHeaders(
-      Object.assign(this.DEFAULT_HEADERS, this.DEFAULT_AUTH_TOKEN_HEADERS)
-    );
-    const body: string = JSON.stringify({
-      Username: process.env.EMAIL,
-      Password: process.env.PASSWORD,
-      ClientId: "9havvat6hm0b962i",
-      Scope:
-        "usage+readfinancial+readsubscription+readpersonal+readloyalty+changesubscription+weblogin",
-    });
-
-    const callback = (response: Response): boolean => {
-      AuthorizationCode = response.headers.get("AuthorizationCode");
-      if (AuthorizationCode != null) return true;
-      return false;
-    };
-
-    await fetchURI(
-      URI,
-      "POST",
-      headers,
-      "getAuthorizationCode",
-      body,
-      callback
-    );
-
-    return AuthorizationCode;
-  }
-
-  public async handleBearerAuthorizationCode() {
-    const authorizationCode: string = await this.getAuthorizationCode();
-    const headers: Headers = makeHeaders(
-      Object.assign(this.DEFAULT_HEADERS, this.DEFAULT_AUTH_TOKEN_HEADERS)
-    );
-    const URI: string = `${this.API_URI}/createtoken`;
-    const body: string = JSON.stringify({
-      AuthorizationCode: authorizationCode,
-    });
-
-    const callback = (response: Response): boolean => {
-      this.BearerAuthorizationCode = response.headers.get("AccessToken");
-      if (this.BearerAuthorizationCode != undefined) return true;
-      return false;
-    };
-
-    await fetchURI(
-      URI,
-      "POST",
-      headers,
-      "handleBearerAuthorizationCode",
-      body,
-      callback
-    );
-  }
 
   private async getSubscriptionsResource(): Promise<SubscriptionsResource> {
     let subscriptionsResource: SubscriptionsResource = null;
-    await this.handleBearerAuthorizationCode();
 
     const URI: string = `${this.API_URI}/account/current?resourcelabel=LinkedSubscriptions`;
     const headers: Headers = makeHeaders(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export function makeHeaders(headersAsObject: object): Headers {
 
 export function checkENVs() {
   if (
-    [process.env.EMAIL, process.env.PASSWORD, process.env.MSISDN].includes(
+    [process.env.AUTHORIZATIONTOKEN, process.env.MSISDN].includes(
       undefined
     )
   ) {


### PR DESCRIPTION
Hey,  I've updated and tested you're docker with the new odido api & login. 

Things changed: 
- Renamed T-Mobile to Odido in readme, User-agent, capi url 
- Removed the username & password login since they removed that endpoint
- Added AUTHORIZATIONTOKEN env variable to set the token. 

What I didn't do: 
I didn't implement the generation of the refresh token, authorization token. This might be possible using [fernet-nodejs](https://github.com/zoran-php/fernet-nodejs/) and then having the user put the response somewhere.
If you want to implement that you can look at my authenticator and as example use this url as loginresponse (contains fake data):
`https://www.odido.nl/loginappresult?token=gAAAAABlAyAop-gCWE_CtL9iek-MJa3_JaBd7WfnDkz0GiDQsUlQzSXMp7oq0ccLqlNhVsR4jbWI9c93gqxwZBCfuTDwzfVwf2cgSWeZWNjBjt6fdZvIiF2aeThB0cTsDcKwUnAzKZk6CkHnZ2uyC99L7vPy-eRsNSh1loCxgdzWLiQaWZJNd_2jfCGr4PAgUSmWSgZgYI4XxTBQPs5FGDCez1Jbw-8DFRoSBf3C3wSxoBF3cDRR7NV97qf2FEmRZogTcvFFSQb1q_mT1PLni1hGteIueMi22Td9q-IAomcH2DoOdbuDWTkld_TCJRQo-zdQq8UNMjUHUzAbR0Q8SVeJwh16L-KnBBbb0iOSK0Dbc2tpsIgNYZvGW3It1jnIqH1RdFmi9GwYx6XY7wCSv2U94dyRXbxfNOQ5G4na4Z4fZfPVvzJ6jKP-U6eEAJcytDPCaKumAPi6qVM_87BSpfL44ZAWPn0Wxg==`

This response contains a one-time refreshtoken